### PR TITLE
feat: update key mapping to exit terminal mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,8 @@ vim.keymap.set("n", "<leader>h", "<cmd>Ex<CR>", { silent = true })
 vim.keymap.set("n", "<leader>dk", "^Dk$pjddk$", { silent = true })
 vim.keymap.set("n", "<leader>dj", "j^Dk$pjddk$", { silent = true })
 
+vim.keymap.set("t", "<c-[><c-[>", "<c-\\><c-n>")
+
 local tab_config = {
   [2] = {"*.lua", "*.html"},
   [4] = {"*.ts", "*.js", "*.rs"},


### PR DESCRIPTION
Update key mapping to exit terminal mode. Mapping copied from: https://github.com/nvim-lua/kickstart.nvim/blob/186018483039b20dc39d7991e4fb28090dd4750e/init.lua#L170-L176.