### PR TITLE
feat: update terminal escape key mapping

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -29,7 +29,7 @@ vim.keymap.set("n", "<leader>h", "<cmd>Ex<CR>", { silent = true })
 vim.keymap.set("n", "<leader>dk", "^Dk$pjddk$", { silent = true })
 vim.keymap.set("n", "<leader>dj", "j^Dk$pjddk$", { silent = true })
 
-vim.keymap.set("t", "<c-[><c-[>", "<c-\\><c-n>")
+vim.keymap.set("t", "<c-]><c-[>", "<c-\\><c-n>")
 
 vim.opt.list = true
 vim.opt.listchars = { tab = "» ", trail = "·", nbsp = "␣" }


### PR DESCRIPTION
Update terminal escape key mapping. This will remove conflict with `<c-[>` mapping in Laygit.