### PR TITLE
revert: remove unnecessary key mappings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,9 +31,6 @@ vim.keymap.set("n", "<leader>k", "<cmd>tabnew<CR>", { silent = true })
 
 vim.keymap.set("n", "<leader>h", "<cmd>Ex<CR>", { silent = true })
 
-vim.keymap.set("n", "<leader>dk", "^Dk$pjddk$", { silent = true })
-vim.keymap.set("n", "<leader>dj", "j^Dk$pjddk$", { silent = true })
-
 vim.keymap.set("t", "<c-]><c-[>", "<c-\\><c-n>")
 
 vim.opt.list = true


### PR DESCRIPTION
revert: remove unnecessary key mappings.