### PR TITLE
chore: have single tmux session across all NeoVim sessions

### DIFF
--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -5,7 +5,7 @@ plugin.config = {
   direction = "float",
   close_on_exit = true,
   on_create = function(t)
-    t:send(string.format("tmux new-session -A -s %s", vim.fn.getcwd()))
+    t:send("tmux new-session -A -s neovim-session")
   end,
 }
 


### PR DESCRIPTION
Have single `tmux` session across all NeoVim sessions.